### PR TITLE
Add custom embed functionality to comic notification messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ function createEmbedFromComic(comic) {
   return embed;
 }
 
-async function getSeries(id, dateDescriptor) {
+async function getSeries(id, name, dateDescriptor) {
   const ts = dayjs().unix().toString();
   const hash = crypto.hash("md5", ts + privKey + pubKey);
 

--- a/index.js
+++ b/index.js
@@ -231,7 +231,6 @@ async function getComics() {
     if (data != null) {
       comics.push(data);
     }
-    console.log(JSON.stringify(data, null, 2));
   }
 
   return comics;


### PR DESCRIPTION
Adds functionality to embed useful information about new comic releases in their respective notifications:

- Title (with link to Marvel.com)
- Release date
- Writer, Penciller, and Cover Artist
- Description
- Cover art

![image](https://github.com/user-attachments/assets/2d7a7cce-fa20-4df2-8116-08e4f727788f)
